### PR TITLE
Add open clip support

### DIFF
--- a/fine_tune.py
+++ b/fine_tune.py
@@ -5,7 +5,7 @@ from fastai.callback.wandb import WandbCallback
 import open_clip
 
 WANDB_PROJECT = 'ft_pets_planet'
-WANDB_ENTITY = 'simonjegou'
+WANDB_ENTITY = 'fastai'
 
 config_defaults = SimpleNamespace(
     batch_size=32,


### PR DESCRIPTION
Add support to [open_clip](https://github.com/mlfoundations/open_clip) models in the `fine_tune.py` script. 

- To install open_clip : `pip install open_clip_torch`
- To get the list all available models and checkpoints : `from open_clip import list_pretrained`
- To finetune a model, input the `model_name` and `clip_checkpoint` arguments (_e.g._ `python fine_tune.py --model_name ViT-L-14 --clip_checkpoint openai`).

For each open_clip model, the linear projection head is removed and a linear layer is added to the model (see the `get_clip_model` function). 

Note that it may be better to first pretrained the linear layer using sklearn before finetuning the whole network (see for instance [Fine-Tuning can Distort Pretrained Features and Underperform Out-of-Distribution](https://arxiv.org/pdf/2202.10054.pdf)).